### PR TITLE
Add AI finding generation

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -501,6 +501,8 @@ HEALTH_CHECK = {
     "MEMORY_MIN": env("HEALTHCHECK_MEM_MIN", default=100),
 }
 REDIS_URL = env("REDIS_URL", default="redis://redis:6379")
+# API keys
+OPENAI_API_KEY = env("OPENAI_API_KEY", default="")
 
 # Tagging
 # ------------------------------------------------------------------------------

--- a/ghostwriter/reporting/templates/reporting/finding_list.html
+++ b/ghostwriter/reporting/templates/reporting/finding_list.html
@@ -32,6 +32,11 @@
     {% csrf_token %}
     <button role="button" class="btn btn-info col-2 icon add-icon">Create Finding</button>
   </form>
+  <form action="{% url 'reporting:finding_ai_create' %}" method="POST" class="mt-2" style="display:flex;gap:4px">
+    {% csrf_token %}
+    <input type="text" name="prompt" class="form-control col-8" placeholder="Describe finding" />
+    <button type="submit" class="btn btn-success col-2 icon add-icon">AI Create</button>
+  </form>
   <a id="resetSortBtn" class="btn btn-secondary col-2 icon sync-icon" role="button">Reset Sort</a>
 
   {% if filter.qs|length == 0 %}

--- a/ghostwriter/reporting/urls.py
+++ b/ghostwriter/reporting/urls.py
@@ -111,6 +111,7 @@ urlpatterns += [
 urlpatterns += [
     path("findings/<int:pk>", ghostwriter.reporting.views2.finding.FindingDetailView.as_view(), name="finding_detail"),
     path("findings/create/", ghostwriter.reporting.views2.finding.FindingCreate.as_view(), name="finding_create"),
+    path("findings/create_ai/", ghostwriter.reporting.views2.finding.AIFindingCreate.as_view(), name="finding_ai_create"),
     path("findings/update/<int:pk>", ghostwriter.reporting.views2.finding.FindingUpdate.as_view(), name="finding_update"),
     path("findings/delete/<int:pk>", ghostwriter.reporting.views2.finding.FindingDelete.as_view(), name="finding_delete"),
     path(

--- a/ghostwriter/reporting/views2/finding.py
+++ b/ghostwriter/reporting/views2/finding.py
@@ -116,6 +116,49 @@ class FindingCreate(RoleBasedAccessControlMixin, View):
         return redirect("reporting:finding_update", pk=obj.id)
 
 
+class AIFindingCreate(RoleBasedAccessControlMixin, View):
+    """Create a new finding using an LLM like ChatGPT."""
+
+    def test_func(self):
+        return Finding.user_can_create(self.request.user)
+
+    def handle_no_permission(self):
+        messages.error(self.request, "You do not have the necessary permission to create new findings.")
+        return redirect("reporting:findings")
+
+    def post(self, request) -> HttpResponse:
+        prompt = request.POST.get("prompt", "").strip()
+        if not prompt:
+            messages.error(request, "You must provide a prompt for AI generation.")
+            return redirect("reporting:findings")
+
+        try:
+            import openai
+            from django.conf import settings
+
+            openai.api_key = settings.OPENAI_API_KEY
+            response = openai.chat.completions.create(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {"role": "system", "content": "You generate security findings for penetration test reports."},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+            content = response.choices[0].message.content.strip()
+        except Exception as exc:  # pragma: no cover - network calls not tested
+            messages.error(request, f"LLM request failed: {exc}")
+            return redirect("reporting:findings")
+
+        obj = Finding(
+            title=prompt[:100],
+            description=content,
+            extra_fields=ExtraFieldSpec.initial_json(Finding),
+        )
+        obj.save()
+        messages.success(request, "AI generated finding created", extra_tags="alert-success")
+        return redirect("reporting:finding_update", pk=obj.id)
+
+
 class ConvertFinding(RoleBasedAccessControlMixin, SingleObjectMixin, View):
     """
     Create a copy of an individual :model:`reporting.ReportFindingLink` and prepare

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -44,4 +44,5 @@ pyjwt==2.9.0
 psutil==6.0.0
 django-taggit==6.1.0
 croniter==3.0.3
+openai==1.97.1
 cvss==3.2


### PR DESCRIPTION
## Summary
- integrate OpenAI library for generating findings
- add OPENAI_API_KEY setting
- implement `AIFindingCreate` view for LLM generation
- include new route and button on findings list page

## Testing
- `flake8` *(fails: isort issues)*
- `pytest -k "Finding" -q` *(fails: sqlite operational error)*

------
https://chatgpt.com/codex/tasks/task_e_68849c90c000832293b7b3398f8e3d08